### PR TITLE
derive Valuable for enum

### DIFF
--- a/valuable-derive/src/expand.rs
+++ b/valuable-derive/src/expand.rs
@@ -1,78 +1,265 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use syn::Ident;
 
 pub(crate) fn derive_valuable(input: &mut syn::DeriveInput) -> TokenStream {
     match &input.data {
         syn::Data::Struct(data) => derive_struct(input, data),
-        // TODO: waiting Enumerable
-        syn::Data::Enum(_data) => unimplemented!("enum is not supported yet"),
+        syn::Data::Enum(data) => derive_enum(input, data),
         // It's probably impossible to derive union because you cannot safely reference the field.
+        // TODO: error instead of panic
         syn::Data::Union(..) => panic!("union is not supported"),
     }
 }
 
 fn derive_struct(input: &syn::DeriveInput, data: &syn::DataStruct) -> TokenStream {
-    if !matches!(data.fields, syn::Fields::Named(..)) {
-        unimplemented!("tuple struct and unit struct are not supported yet")
-    }
+    let name = &input.ident;
+    let name_literal = name.to_string();
+    let visit_fields;
+    let struct_def;
+    let mut named_fields_statics = None;
 
-    let static_fields_static_name = format_ident!("{}_FIELDS", input.ident);
-    let static_fields = data.fields.iter().map(|f| {
-        let name = f.ident.as_ref().unwrap().to_string();
-        quote! {
-            ::valuable::field::NamedField::new(#name),
-        }
-    });
-    let static_fields_static = quote! {
-        static #static_fields_static_name: &[::valuable::field::NamedField<'static>] = &[
-            #(#static_fields)*
-        ];
-    };
+    match &data.fields {
+        syn::Fields::Named(_) => {
+            // <struct>_FIELDS
+            let named_fields_static_name = format_ident!("{}_FIELDS", input.ident);
+            named_fields_statics =
+                Some(named_fields_static(&named_fields_static_name, &data.fields));
 
-    let ident = &input.ident;
-    let ident_str = ident.to_string();
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let as_values = data.fields.iter().map(|f| {
-        let ident = f.ident.as_ref();
-        quote! {
-            ::valuable::Valuable::as_value(&self.#ident),
-        }
-    });
-    let structable_impl = quote! {
-        impl #impl_generics ::valuable::Structable for #ident #ty_generics #where_clause {
-            fn definition(&self) -> ::valuable::StructDef<'_> {
+            struct_def = quote! {
                 ::valuable::StructDef {
-                    name: #ident_str,
-                    fields: ::valuable::field::Fields::NamedStatic(#static_fields_static_name),
+                    name: #name_literal,
+                    fields: ::valuable::field::Fields::NamedStatic(#named_fields_static_name),
                     is_dynamic: false,
                 }
-            }
+            };
 
-            fn visit(&self, v: &mut dyn ::valuable::Visit) {
-                v.visit_named_fields(&::valuable::NamedValues::new(
-                    #static_fields_static_name,
+            let fields = data.fields.iter().map(|field| field.ident.as_ref());
+            visit_fields = quote! {
+                visitor.visit_named_fields(&::valuable::NamedValues::new(
+                    #named_fields_static_name,
                     &[
-                        #(#as_values)*
+                        #(::valuable::Valuable::as_value(&self.#fields),)*
                     ],
                 ));
+            }
+        }
+        syn::Fields::Unnamed(_) | syn::Fields::Unit => {
+            struct_def = quote! {
+                ::valuable::StructDef {
+                    name: #name_literal,
+                    fields: ::valuable::field::Fields::Unnamed,
+                    is_dynamic: false,
+                }
+            };
+
+            let indices = (0..data.fields.len()).map(syn::Index::from);
+            visit_fields = quote! {
+                visitor.visit_unnamed_fields(
+                    &[
+                        #(::valuable::Valuable::as_value(&self.#indices),)*
+                    ],
+                );
+            };
+        }
+    }
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let structable_impl = quote! {
+        impl #impl_generics ::valuable::Structable for #name #ty_generics #where_clause {
+            fn definition(&self) -> ::valuable::StructDef<'_> {
+                #struct_def
+            }
+
+            fn visit(&self, visitor: &mut dyn ::valuable::Visit) {
+                #visit_fields
             }
         }
     };
 
     let valuable_impl = quote! {
-        impl #impl_generics ::valuable::Valuable for #ident #ty_generics #where_clause {
+        impl #impl_generics ::valuable::Valuable for #name #ty_generics #where_clause {
             fn as_value(&self) -> ::valuable::Value<'_> {
                 ::valuable::Value::Structable(self)
             }
         }
     };
 
+    let allowed_lints = allowed_lints();
     quote! {
-        #[allow(non_upper_case_globals)]
+        #allowed_lints
         const _: () = {
-            #static_fields_static
+            #named_fields_statics
             #structable_impl
             #valuable_impl
         };
+    }
+}
+
+fn derive_enum(input: &syn::DeriveInput, data: &syn::DataEnum) -> TokenStream {
+    // <enum>_VARIANTS
+    let variants_static_name = format_ident!("{}_VARIANTS", input.ident);
+    // `static FIELDS: &[NamedField<'static>]` for variant with named fields
+    let mut named_fields_statics = vec![];
+    let mut variant_defs = vec![];
+    let mut visit_variants = vec![];
+
+    for variant in &data.variants {
+        match &variant.fields {
+            syn::Fields::Named(_) => {
+                // <enum>_<variant>_FIELDS
+                let named_fields_static_name =
+                    format_ident!("{}_{}_FIELDS", input.ident, variant.ident);
+                named_fields_statics.push(named_fields_static(
+                    &named_fields_static_name,
+                    &variant.fields,
+                ));
+
+                let variant_name = &variant.ident;
+                let variant_name_literal = variant_name.to_string();
+                variant_defs.push(quote! {
+                    ::valuable::VariantDef {
+                        name: #variant_name_literal,
+                        fields: ::valuable::field::Fields::NamedStatic(#named_fields_static_name),
+                        is_dynamic: false,
+                    },
+                });
+
+                let fields: Vec<_> = variant
+                    .fields
+                    .iter()
+                    .map(|field| field.ident.as_ref())
+                    .collect();
+                visit_variants.push(quote! {
+                    Self::#variant_name { #(#fields),* } => {
+                        visitor.visit_variant_named_fields(
+                            &::valuable::Variant { name: #variant_name_literal },
+                            &::valuable::NamedValues::new(
+                                #named_fields_static_name,
+                                &[
+                                    #(::valuable::Valuable::as_value(#fields),)*
+                                ],
+                            ),
+                        );
+                    }
+                });
+            }
+            syn::Fields::Unnamed(_) => {
+                let variant_name = &variant.ident;
+                let variant_name_literal = variant_name.to_string();
+                variant_defs.push(quote! {
+                    ::valuable::VariantDef {
+                        name: #variant_name_literal,
+                        fields: ::valuable::field::Fields::Unnamed,
+                        is_dynamic: false,
+                    },
+                });
+
+                let bindings: Vec<_> = (0..variant.fields.len())
+                    .map(|i| format_ident!("__binding_{}", i))
+                    .collect();
+                visit_variants.push(quote! {
+                    Self::#variant_name(#(#bindings),*) => {
+                        visitor.visit_variant_unnamed_fields(
+                            &::valuable::Variant { name: #variant_name_literal },
+                            &[
+                                #(::valuable::Valuable::as_value(#bindings),)*
+                            ],
+                        );
+                    }
+                });
+            }
+            syn::Fields::Unit => {
+                let variant_name = &variant.ident;
+                let variant_name_literal = variant_name.to_string();
+                variant_defs.push(quote! {
+                    ::valuable::VariantDef {
+                        name: #variant_name_literal,
+                        fields: ::valuable::field::Fields::Unnamed,
+                        is_dynamic: false,
+                    },
+                });
+
+                visit_variants.push(quote! {
+                    Self::#variant_name => {
+                        visitor.visit_variant_unnamed_fields(
+                            &::valuable::Variant { name: #variant_name_literal },
+                            &[],
+                        );
+                    }
+                });
+            }
+        }
+    }
+    let variants_static = quote! {
+        static #variants_static_name: &[::valuable::VariantDef<'static>] = &[
+            #(#variant_defs)*
+        ];
+    };
+
+    let name = &input.ident;
+    let name_literal = name.to_string();
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let enumerable_impl = quote! {
+        impl #impl_generics ::valuable::Enumerable for #name #ty_generics #where_clause {
+            fn definition(&self) -> ::valuable::EnumDef<'_> {
+                ::valuable::EnumDef {
+                    name: #name_literal,
+                    variants: #variants_static_name,
+                    is_dynamic: false,
+                }
+            }
+
+            fn visit(&self, visitor: &mut dyn ::valuable::Visit) {
+                match self {
+                    #(#visit_variants)*
+                }
+            }
+        }
+    };
+
+    let valuable_impl = quote! {
+        impl #impl_generics ::valuable::Valuable for #name #ty_generics #where_clause {
+            fn as_value(&self) -> ::valuable::Value<'_> {
+                ::valuable::Value::Enumerable(self)
+            }
+        }
+    };
+
+    let allowed_lints = allowed_lints();
+    quote! {
+        #allowed_lints
+        const _: () = {
+            #(#named_fields_statics)*
+            #variants_static
+            #enumerable_impl
+            #valuable_impl
+        };
+    }
+}
+
+// `static <name>: &[NamedField<'static>] = &[ ... ];`
+fn named_fields_static(name: &Ident, fields: &syn::Fields) -> TokenStream {
+    debug_assert!(matches!(fields, syn::Fields::Named(..)));
+    let named_fields = fields.iter().map(|field| {
+        let field_name_literal = field.ident.as_ref().unwrap().to_string();
+        quote! {
+            ::valuable::field::NamedField::new(#field_name_literal),
+        }
+    });
+    quote! {
+        static #name: &[::valuable::field::NamedField<'static>] = &[
+            #(#named_fields)*
+        ];
+    }
+}
+
+// Returns attributes that should be applied to generated code.
+fn allowed_lints() -> TokenStream {
+    quote! {
+        #[allow(non_upper_case_globals)]
+        #[allow(clippy::unknown_clippy_lints)]
+        #[allow(clippy::used_underscore_binding)]
     }
 }

--- a/valuable/src/enumerable.rs
+++ b/valuable/src/enumerable.rs
@@ -31,7 +31,7 @@ pub struct VariantDef<'a> {
 }
 
 pub struct Variant<'a> {
-    name: &'a str,
+    pub name: &'a str,
 }
 
 impl EnumDef<'_> {
@@ -60,7 +60,7 @@ impl fmt::Debug for dyn Enumerable + '_ {
             name: &'b str,
             fmt: &'b mut fmt::Formatter<'a>,
             res: fmt::Result,
-        };
+        }
 
         impl Visit for DebugEnumerable<'_, '_> {
             fn visit_variant_named_fields(

--- a/valuable/src/value.rs
+++ b/valuable/src/value.rs
@@ -1,6 +1,6 @@
-use crate::{Listable, Structable, Valuable};
+use crate::{Enumerable, Listable, Structable, Valuable};
 
-use std::fmt;
+use std::fmt::{self, Debug};
 
 #[non_exhaustive]
 pub enum Value<'a> {
@@ -25,6 +25,7 @@ pub enum Value<'a> {
     Error(&'a dyn std::error::Error),
     Listable(&'a dyn Listable),
     Structable(&'a dyn Structable),
+    Enumerable(&'a dyn Enumerable),
 }
 
 impl Valuable for Value<'_> {
@@ -52,6 +53,7 @@ impl Valuable for Value<'_> {
             Unit => Unit,
             Listable(v) => Listable(v),
             Structable(v) => Structable(v),
+            Enumerable(v) => Enumerable(v),
             _ => unimplemented!(),
         }
     }
@@ -69,6 +71,16 @@ impl fmt::Debug for Value<'_> {
 
         match *self {
             String(v) => v.fmt(fmt),
+            Char(v) => v.fmt(fmt),
+            Bool(v) => v.fmt(fmt),
+            F32(v) => v.fmt(fmt),
+            F64(v) => v.fmt(fmt),
+            I8(v) => v.fmt(fmt),
+            I16(v) => v.fmt(fmt),
+            I32(v) => v.fmt(fmt),
+            I64(v) => v.fmt(fmt),
+            I128(v) => v.fmt(fmt),
+            Isize(v) => v.fmt(fmt),
             U8(v) => v.fmt(fmt),
             U16(v) => v.fmt(fmt),
             U32(v) => v.fmt(fmt),
@@ -79,8 +91,8 @@ impl fmt::Debug for Value<'_> {
             Error(v) => fmt::Debug::fmt(v, fmt),
             Listable(v) => v.fmt(fmt),
             Structable(v) => v.fmt(fmt),
+            Enumerable(v) => v.fmt(fmt),
             // Structable(v) => structable::debug(v, fmt),
-            _ => unimplemented!(),
         }
     }
 }

--- a/valuable/tests/derive.rs
+++ b/valuable/tests/derive.rs
@@ -1,0 +1,39 @@
+use valuable::Valuable;
+
+#[test]
+fn test_derive_struct() {
+    #[derive(Valuable)]
+    struct Struct {
+        x: &'static str,
+    }
+
+    #[derive(Valuable)]
+    struct Tuple(u8);
+
+    #[derive(Valuable)]
+    struct Unit;
+
+    let v = Struct { x: "a" };
+    assert_eq!(format!("{:?}", v.as_value()), r#"Struct { x: "a" }"#);
+    let v = Tuple(0);
+    assert_eq!(format!("{:?}", v.as_value()), r#"Tuple(0)"#);
+    let v = Unit;
+    assert_eq!(format!("{:?}", v.as_value()), r#"Unit"#);
+}
+
+#[test]
+fn test_derive_enum() {
+    #[derive(Valuable)]
+    enum Enum {
+        Struct { x: &'static str },
+        Tuple(u8),
+        Unit,
+    }
+
+    let v = Enum::Struct { x: "a" };
+    assert_eq!(format!("{:?}", v.as_value()), r#"Enum::Struct { x: "a" }"#);
+    let v = Enum::Tuple(0);
+    assert_eq!(format!("{:?}", v.as_value()), r#"Enum::Tuple(0)"#);
+    let v = Enum::Unit;
+    assert_eq!(format!("{:?}", v.as_value()), r#"Enum::Unit"#);
+}

--- a/valuable/tests/enumerable.rs
+++ b/valuable/tests/enumerable.rs
@@ -1,0 +1,71 @@
+use valuable::field::*;
+use valuable::*;
+
+#[test]
+fn test_manual_impl() {
+    enum Enum {
+        Struct { x: &'static str },
+        Tuple(u8),
+        Unit,
+    }
+
+    static ENUM_STRUCT_FIELDS: &[NamedField<'static>] = &[NamedField::new("x")];
+    static ENUM_VARIANTS: &[VariantDef<'static>] = &[
+        VariantDef {
+            name: "Struct",
+            fields: Fields::NamedStatic(&ENUM_STRUCT_FIELDS),
+            is_dynamic: false,
+        },
+        VariantDef {
+            name: "Tuple",
+            fields: Fields::Unnamed,
+            is_dynamic: false,
+        },
+        VariantDef {
+            name: "Unit",
+            fields: Fields::Unnamed,
+            is_dynamic: false,
+        },
+    ];
+
+    impl Enumerable for Enum {
+        fn definition(&self) -> EnumDef<'_> {
+            EnumDef {
+                name: "Enum",
+                variants: ENUM_VARIANTS,
+                is_dynamic: false,
+            }
+        }
+
+        fn visit(&self, visitor: &mut dyn Visit) {
+            match self {
+                Enum::Struct { x } => {
+                    visitor.visit_variant_named_fields(
+                        &Variant { name: "Struct" },
+                        &NamedValues::new(ENUM_STRUCT_FIELDS, &[Value::String(x)]),
+                    );
+                }
+                Enum::Tuple(y) => {
+                    visitor
+                        .visit_variant_unnamed_fields(&Variant { name: "Tuple" }, &[Value::U8(*y)]);
+                }
+                Enum::Unit => {
+                    visitor.visit_variant_unnamed_fields(&Variant { name: "Unit" }, &[]);
+                }
+            }
+        }
+    }
+
+    impl Valuable for Enum {
+        fn as_value(&self) -> Value<'_> {
+            Value::Enumerable(self)
+        }
+    }
+
+    let v = Enum::Struct { x: "a" };
+    assert_eq!(format!("{:?}", v.as_value()), r#"Enum::Struct { x: "a" }"#);
+    let v = Enum::Tuple(0);
+    assert_eq!(format!("{:?}", v.as_value()), r#"Enum::Tuple(0)"#);
+    let v = Enum::Unit;
+    assert_eq!(format!("{:?}", v.as_value()), r#"Enum::Unit"#);
+}


### PR DESCRIPTION
Closes #2 

This also adds support for derive Valuable for tuple struct.


From:

```rust
#[derive(Valuable)]
enum Enum {
    Struct { x: &'static str },
    Tuple(u8),
    Unit,
}
```

To:
```rust
const _: () = {
    static Enum_Struct_FIELDS: &[::valuable::field::NamedField<'static>] =&[
        ::valuable::field::NamedField::new("x"),
    ];
    static Enum_VARIANTS: &[::valuable::VariantDef<'static>] = &[
        ::valuable::VariantDef {
            name: "Struct",
            fields: ::valuable::field::Fields::NamedStatic(Enum_Struct_FIELDS),
            is_dynamic: false,
        },
        ::valuable::VariantDef {
            name: "Tuple",
            fields: ::valuable::field::Fields::Unnamed,
            is_dynamic: false,
        },
        ::valuable::VariantDef {
            name: "Unit",
            fields: ::valuable::field::Fields::Unnamed,
            is_dynamic: false,
        },
    ];
    impl ::valuable::Enumerable for Enum {
        fn definition(&self) -> ::valuable::EnumDef<'_> {
            ::valuable::EnumDef {
                name: "Enum",
                variants: Enum_VARIANTS,
                is_dynamic: false,
            }
        }
        fn visit(&self, visitor: &mut dyn ::valuable::Visit) {
            match self {
                Self::Struct { x } => {
                    visitor.visit_variant_named_fields(
                        &::valuable::Variant { name: "Struct" },
                        &::valuable::NamedValues::new(
                            Enum_Struct_FIELDS,
                            &[::valuable::Valuable::as_value(x)],
                        ),
                    );
                }
                Self::Tuple(__binding_0) => {
                    visitor.visit_variant_unnamed_fields(
                        &::valuable::Variant { name: "Tuple" },
                        &[::valuable::Valuable::as_value(__binding_0)],
                    );
                }
                Self::Unit => {
                    visitor.visit_variant_unnamed_fields(
                        &::valuable::Variant { name: "Unit" },
                        &[],
                    );
                }
            }
        }
    }
    impl ::valuable::Valuable for Enum {
        fn as_value(&self) -> ::valuable::Value<'_> {
            ::valuable::Value::Enumerable(self)
        }
    }
};
```
